### PR TITLE
hapi 17 support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,11 +46,13 @@ The default `request` serializer. Returns and object:
 
 ```js
 {
-  id: 'string', // Default is an empty string. Attach a synchronous function
-                // to the input `request` that returns an identifier to have
+  id: 'string', // Default is an empty string, unless there is an `id` property 
+                // already attached to the `request` object or to the `request.info`
+                // object. Attach a synchronous function
+                // to the `request.id` that returns an identifier to have
                 // the value filled.
   method: 'string',
-  url: 'string',
+  url: 'string', // the request pathname (as per req.url in core HTTP)
   headers: Object,
   remoteAddress: 'string',
   remotePort: Number,

--- a/lib/req.js
+++ b/lib/req.js
@@ -55,9 +55,9 @@ Object.defineProperty(pinoReqProto, rawSymbol, {
 function reqSerializer (req) {
   var connection = req.connection
   const _req = Object.create(pinoReqProto)
-  _req.id = typeof req.id === 'function' ? req.id() : req.id
+  _req.id = (typeof req.id === 'function' ? req.id() : (req.id || (req.info && req.info.id))) || ''
   _req.method = req.method
-  _req.url = req.url
+  _req.url = req.url.path || req.url
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress
   _req.remotePort = connection && connection.remotePort

--- a/lib/req.js
+++ b/lib/req.js
@@ -55,12 +55,15 @@ Object.defineProperty(pinoReqProto, rawSymbol, {
 function reqSerializer (req) {
   var connection = req.connection
   const _req = Object.create(pinoReqProto)
+  // req.info is for hapi compat.
   _req.id = (typeof req.id === 'function' ? req.id() : (req.id || (req.info && req.info.id))) || ''
   _req.method = req.method
-  _req.url = req.url.path || req.url
+  // req.url.path is  for hapi compat.
+  _req.url = req.url ? (req.url.path || req.url) : undefined
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress
   _req.remotePort = connection && connection.remotePort
+  // req.raw is  for hapi compat/equivalence
   _req.raw = req.raw || req
   return _req
 }

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -63,6 +63,26 @@ test('req.raw is available', function (t) {
   }
 })
 
+test('req.raw will be obtained in from input request raw property if input request raw property is truthy', function (t) {
+  t.plan(2)
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.tearDown(() => server.close())
+
+  function handler (req, res) {
+    req.raw = { req: {foo: 'foo'}, res: {} }
+    var serialized = serializers.reqSerializer(req)
+    t.ok(serialized.raw)
+    t.is(serialized.raw.req.foo, 'foo')
+    res.end()
+  }
+})
+
 test('req.id has a non-function value', function (t) {
   t.plan(1)
 
@@ -77,6 +97,25 @@ test('req.id has a non-function value', function (t) {
   function handler (req, res) {
     var serialized = serializers.reqSerializer(req)
     t.is(typeof serialized.id === 'function', false)
+    res.end()
+  }
+})
+
+test('req.id will be obtained from input request info.id when input request id does not exist', function (t) {
+  t.plan(1)
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.tearDown(() => server.close())
+
+  function handler (req, res) {
+    req.info = {id: 'test'}
+    var serialized = serializers.reqSerializer(req)
+    t.is(serialized.id, 'test')
     res.end()
   }
 })
@@ -97,6 +136,25 @@ test('req.id has a non-function value with custom id function', function (t) {
     var serialized = serializers.reqSerializer(req)
     t.is(typeof serialized.id === 'function', false)
     t.is(serialized.id, 42)
+    res.end()
+  }
+})
+
+test('req.url will be obtained from input request url.path when input request url is an object', function (t) {
+  t.plan(1)
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.tearDown(() => server.close())
+
+  function handler (req, res) {
+    req.url = {path: '/test'}
+    var serialized = serializers.reqSerializer(req)
+    t.is(serialized.url, '/test')
     res.end()
   }
 })


### PR DESCRIPTION
in order to integrate `stdSerializer` in to `hapi-pino` v4.x.x whilst keeping it consistent with current (and other ecosystem) implementations we have to 

* get hapi's req id from req.info
* get the url (equivalent) from req.url.path 

hopefully this doesn't penalize other loggers too much, we could create as sep. request serializer for hapi (maybe in pino-std-serializers) ?

