### PR TITLE
err: support serializing nested errors

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -2,7 +2,11 @@
 
 module.exports = errSerializer
 
+var seen = Symbol('circular-ref-tag')
+
 function errSerializer (err) {
+  err[seen] = undefined // tag to prevent re-looking at this
+
   var obj = {
     type: err.constructor.name,
     message: err.message,
@@ -10,8 +14,17 @@ function errSerializer (err) {
   }
   for (var key in err) {
     if (obj[key] === undefined) {
-      obj[key] = err[key]
+      var val = err[key]
+      if (val instanceof Error) {
+        if (!val.hasOwnProperty(seen)) {
+          obj[key] = errSerializer(val)
+        }
+      } else {
+        obj[key] = val
+      }
     }
   }
+
+  delete err[seen] // clean up tag in case err is serialized again later
   return obj
 }


### PR DESCRIPTION
Nested errors with stack-traces can be a useful way of propagating error information. This PR enables recursively serializing nested errors while protecting against circular references.