### PR TITLE
serialize headers (renamed header to headers)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,7 +70,7 @@ The default `response` serializer. Returns an object:
 ```js
 {
   statusCode: Number,
-  header: Array, // The list of headers to be sent in the response.
+  headers: Object, // The headers to be sent in the response.
   raw: Object // Non-enumerable, i.e. will not be in the output, original
               // response object. This is available for subsequent serializers
               // to use.

--- a/lib/res.js
+++ b/lib/res.js
@@ -12,7 +12,7 @@ var pinoResProto = Object.create({}, {
     writable: true,
     value: 0
   },
-  header: {
+  headers: {
     enumerable: true,
     writable: true,
     value: ''
@@ -35,7 +35,7 @@ Object.defineProperty(pinoResProto, rawSymbol, {
 function resSerializer (res) {
   const _res = Object.create(pinoResProto)
   _res.statusCode = res.statusCode
-  _res.header = res._header
+  _res.headers = res._headers
   _res.raw = res
   return _res
 }

--- a/test/res.test.js
+++ b/test/res.test.js
@@ -68,3 +68,22 @@ test('can wrap response serializers', function (t) {
     res.end()
   }
 })
+
+test('res.headers is serialized', function (t) {
+  t.plan(1)
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.tearDown(() => server.close())
+
+  function handler (req, res) {
+    res.setHeader('x-custom', 'y')
+    var serialized = serializers.resSerializer(res)
+    t.is(serialized.headers['x-custom'], 'y')
+    res.end()
+  }
+})


### PR DESCRIPTION
Currently headers are not sent when logging a http response.

```javascript
log.child({ res }).debug('response!')
```
currently returns 
```json
{
  "statusCode": 200,
  "header": null
}
```
This `PR` makes sure that "headers" are sent instead of "header".

Also added a test 😄 