### PR TITLE
Fix serialized request url being wrong when using Express

### DIFF
--- a/lib/req.js
+++ b/lib/req.js
@@ -58,9 +58,13 @@ function reqSerializer (req) {
   const _req = Object.create(pinoReqProto)
   _req.id = (typeof req.id === 'function' ? req.id() : (req.id || (req.info ? req.info.id : undefined)))
   _req.method = req.method
-  // req.url.path is  for hapi compat.
   // req.originalUrl is for expressjs compat.
-  _req.url = req.originalUrl ? req.originalUrl : (req.url ? (req.url.path || req.url) : undefined)
+  if (req.originalUrl) {
+    _req.url = req.originalUrl
+  } else {
+    // req.url.path is  for hapi compat.
+    _req.url = req.url ? (req.url.path || req.url) : undefined
+  }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress
   _req.remotePort = connection && connection.remotePort

--- a/lib/req.js
+++ b/lib/req.js
@@ -59,7 +59,8 @@ function reqSerializer (req) {
   _req.id = (typeof req.id === 'function' ? req.id() : (req.id || (req.info ? req.info.id : undefined)))
   _req.method = req.method
   // req.url.path is  for hapi compat.
-  _req.url = req.url ? (req.url.path || req.url) : undefined
+  // req.originalUrl is for expressjs compat.
+  _req.url = req.originalUrl ? req.originalUrl : (req.url ? (req.url.path || req.url) : undefined)
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress
   _req.remotePort = connection && connection.remotePort

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -177,6 +177,25 @@ test('req.url will be obtained from input request url.path when input request ur
   }
 })
 
+test('req.url will be obtained from input request originalUrl when available', function (t) {
+  t.plan(1)
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.tearDown(() => server.close())
+
+  function handler (req, res) {
+    req.originalUrl = '/test'
+    var serialized = serializers.reqSerializer(req)
+    t.is(serialized.url, '/test')
+    res.end()
+  }
+})
+
 test('can wrap request serializers', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
This fixes https://github.com/pinojs/pino-std-serializers/issues/21 by using `req.originalUrl` when available.