### PR TITLE
Fix #23 use getHeaders() instead of deprecated _headers

### DIFF
--- a/lib/res.js
+++ b/lib/res.js
@@ -35,7 +35,7 @@ Object.defineProperty(pinoResProto, rawSymbol, {
 function resSerializer (res) {
   const _res = Object.create(pinoResProto)
   _res.statusCode = res.statusCode
-  _res.headers = res.getHeaders()
+  _res.headers = res.getHeaders ? res.getHeaders() : res._headers
   _res.raw = res
   return _res
 }

--- a/lib/res.js
+++ b/lib/res.js
@@ -35,7 +35,7 @@ Object.defineProperty(pinoResProto, rawSymbol, {
 function resSerializer (res) {
   const _res = Object.create(pinoResProto)
   _res.statusCode = res.statusCode
-  _res.headers = res._headers
+  _res.headers = res.getHeaders()
   _res.raw = res
   return _res
 }


### PR DESCRIPTION
By Node.js documentation: 

```
The http module outgoingMessage._headers and outgoingMessage._headerNames properties are deprecated. Use one of the public methods (e.g. outgoingMessage.getHeader(), outgoingMessage.getHeaders(), outgoingMessage.getHeaderNames(), outgoingMessage.hasHeader(), outgoingMessage.removeHeader(), outgoingMessage.setHeader()) for working with outgoing headers.
```

It will fix `[DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated` warning message.