### PR TITLE
fix: guard on err.constructor

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -42,7 +42,9 @@ function errSerializer (err) {
 
   err[seen] = undefined // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
-  _err.type = err.constructor.name
+  _err.type = typeof err.constructor === 'object' && err.constructor !== null
+    ? err.constructor.name
+    : err.name
   _err.message = err.message
   _err.stack = err.stack
   for (const key in err) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -2,6 +2,7 @@
 
 module.exports = errSerializer
 
+const { toString } = Object.prototype.toString
 const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
 const pinoErrProto = Object.create({}, {
@@ -42,7 +43,7 @@ function errSerializer (err) {
 
   err[seen] = undefined // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
-  _err.type = typeof err.constructor === 'object' && err.constructor !== null
+  _err.type = toString.call(err.constructor) === '[object Object]'
     ? err.constructor.name
     : err.name
   _err.message = err.message

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -76,6 +76,32 @@ test('err.raw is available', function (t) {
   t.equal(serialized.raw, err)
 })
 
+test('redefined err.constructor doesnt crash serializer', function (t) {
+  t.plan(8)
+
+  function check (a, name) {
+    t.is(a.type, name)
+    t.is(a.message, 'foo')
+  }
+
+  const err1 = TypeError('foo')
+  err1.constructor = '10'
+
+  const err2 = TypeError('foo')
+  err2.constructor = undefined
+
+  const err3 = Error('foo')
+  err3.constructor = null
+
+  const err4 = Error('foo')
+  err4.constructor = 10
+
+  check(serializer(err1), 'TypeError')
+  check(serializer(err2), 'TypeError')
+  check(serializer(err3), 'Error')
+  check(serializer(err4), 'Error')
+})
+
 test('pass through anything that is not an Error', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
fixes potential crash in the serializer when err.constructor was modified by introducing a guard on err.constructor that verifies that err.constructor is an object, falls back to getting type from err.name in case this resolves negatively