### PR TITLE
add req.socket preference over req.connection

### DIFF
--- a/lib/req.js
+++ b/lib/req.js
@@ -54,7 +54,7 @@ Object.defineProperty(pinoReqProto, rawSymbol, {
 
 function reqSerializer (req) {
   // req.info is for hapi compat.
-  const connection = req.info || req.connection
+  const connection = req.info || req.socket || req.connection
   const _req = Object.create(pinoReqProto)
   _req.id = (typeof req.id === 'function' ? req.id() : (req.id || (req.info ? req.info.id : undefined)))
   _req.method = req.method


### PR DESCRIPTION
So fastify can stop emitting deprecation warnings