### PR TITLE
fix err.constructor guard: err.constructor is a function

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -43,7 +43,7 @@ function errSerializer (err) {
 
   err[seen] = undefined // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
-  _err.type = toString.call(err.constructor) === '[object Object]'
+  _err.type = toString.call(err.constructor) === '[object Function]'
     ? err.constructor.name
     : err.name
   _err.message = err.message


### PR DESCRIPTION
Pull #32 introduced a guard on err.constructor having been modified
such that it wasn't usable. However the comparison should be if it
is a *function*, not an object.

Before this change `_err.type` would also use the `: err.name` branch
of the ternary.