### PR TITLE
Support for aggregate errors

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -57,11 +57,7 @@ function errSerializer (err) {
   _err.stack = stackWithCauses(err)
 
   if (global.AggregateError !== undefined && err instanceof global.AggregateError && Array.isArray(err.errors)) {
-    // check if aggregate error includes itself in the list of errors
-    _err.aggregateErrors = err.errors.reduce((result, error) => {
-      if (error !== err) result.push(errSerializer(error))
-      return result
-    }, [])
+    _err.aggregateErrors = err.errors.map(err => errSerializer(err))
   }
 
   for (const key in err) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -4,7 +4,6 @@ module.exports = errSerializer
 
 const { messageWithCauses, stackWithCauses } = require('./err-helpers')
 
-const hasAggregateError = !!global.AggregateError
 const { toString } = Object.prototype
 const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
@@ -56,10 +55,15 @@ function errSerializer (err) {
     : err.name
   _err.message = messageWithCauses(err)
   _err.stack = stackWithCauses(err)
-  // eslint-disable-next-line no-undef
-  if (hasAggregateError && err instanceof AggregateError && Array.isArray(err.errors)) {
-    _err.aggregateErrors = err.errors.map(err => errSerializer(err))
+
+  if (global.AggregateError !== undefined && err instanceof global.AggregateError && Array.isArray(err.errors)) {
+    // check if aggregate error includes itself in the list of errors
+    _err.aggregateErrors = err.errors.reduce((result, error) => {
+      if (error !== err) result.push(errSerializer(error))
+      return result
+    }, [])
   }
+
   for (const key in err) {
     if (_err[key] === undefined) {
       const val = err[key]

--- a/lib/err.js
+++ b/lib/err.js
@@ -4,7 +4,7 @@ module.exports = errSerializer
 
 const { messageWithCauses, stackWithCauses } = require('./err-helpers')
 
-const major = Number(process.versions.node.split('.')[0])
+const hasAggregateError = !!global.AggregateError
 const { toString } = Object.prototype
 const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
@@ -57,7 +57,7 @@ function errSerializer (err) {
   _err.message = messageWithCauses(err)
   _err.stack = stackWithCauses(err)
   // eslint-disable-next-line no-undef
-  if (major >= 15 && err instanceof AggregateError && err.errors && Array.isArray(err.errors)) {
+  if (hasAggregateError && err instanceof AggregateError && err.errors && Array.isArray(err.errors)) {
     _err.aggregateErrors = err.errors.map(errSerializer)
   }
   for (const key in err) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -4,6 +4,7 @@ module.exports = errSerializer
 
 const { messageWithCauses, stackWithCauses } = require('./err-helpers')
 
+const major = Number(process.versions.node.split('.')[0])
 const { toString } = Object.prototype
 const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
@@ -19,6 +20,11 @@ const pinoErrProto = Object.create({}, {
     value: undefined
   },
   stack: {
+    enumerable: true,
+    writable: true,
+    value: undefined
+  },
+  aggregateErrors: {
     enumerable: true,
     writable: true,
     value: undefined
@@ -50,6 +56,10 @@ function errSerializer (err) {
     : err.name
   _err.message = messageWithCauses(err)
   _err.stack = stackWithCauses(err)
+  // eslint-disable-next-line no-undef
+  if (major >= 15 && err instanceof AggregateError && err.errors && Array.isArray(err.errors)) {
+    _err.aggregateErrors = err.errors.map(errSerializer)
+  }
   for (const key in err) {
     if (_err[key] === undefined) {
       const val = err[key]

--- a/lib/err.js
+++ b/lib/err.js
@@ -58,7 +58,7 @@ function errSerializer (err) {
   _err.stack = stackWithCauses(err)
   // eslint-disable-next-line no-undef
   if (hasAggregateError && err instanceof AggregateError && Array.isArray(err.errors)) {
-    _err.aggregateErrors = err.errors.map(errSerializer)
+    _err.aggregateErrors = err.errors.map(err => errSerializer(err))
   }
   for (const key in err) {
     if (_err[key] === undefined) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -57,7 +57,7 @@ function errSerializer (err) {
   _err.message = messageWithCauses(err)
   _err.stack = stackWithCauses(err)
   // eslint-disable-next-line no-undef
-  if (hasAggregateError && err instanceof AggregateError && err.errors && Array.isArray(err.errors)) {
+  if (hasAggregateError && err instanceof AggregateError && Array.isArray(err.errors)) {
     _err.aggregateErrors = err.errors.map(errSerializer)
   }
   for (const key in err) {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint-ci": "standard",
-    "test": "tap --no-cov 'test/**/*.test.js'",
-    "test-ci": "tap --cov --no-check-coverage --coverage-report=text 'test/**/*.test.js'",
+    "test": "tap --no-cov test/**/*.test.js",
+    "test-ci": "tap --cov --no-check-coverage --coverage-report=text test/**/*.test.js",
     "test-types": "tsc && tsd"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint-ci": "standard",
-    "test": "tap --no-cov test/**/*.test.js",
-    "test-ci": "tap --cov --no-check-coverage --coverage-report=text test/**/*.test.js",
+    "test": "tap --no-cov 'test/**/*.test.js'",
+    "test-ci": "tap --cov --no-check-coverage --coverage-report=text 'test/**/*.test.js'",
     "test-types": "tsc && tsd"
   },
   "repository": {

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -3,24 +3,6 @@
 const test = require('tap').test
 const serializer = require('../lib/err')
 const wrapErrorSerializer = require('../').wrapErrorSerializer
-const hasAggregateError = !!global.AggregateError
-
-test('serializes aggregate errors', { skip: !hasAggregateError }, function (t) {
-  t.plan(8)
-  const foo = new Error('foo')
-  const bar = new Error('bar')
-  const aggregate = new AggregateError([foo, bar], 'aggregated message') // eslint-disable-line no-undef
-
-  const serialized = serializer(aggregate)
-  t.equal(serialized.type, 'AggregateError')
-  t.equal(serialized.message, 'aggregated message')
-  t.equal(serialized.aggregateErrors.length, 2)
-  t.equal(serialized.aggregateErrors[0].message, 'foo')
-  t.equal(serialized.aggregateErrors[1].message, 'bar')
-  t.match(serialized.aggregateErrors[0].stack, /^Error: foo/)
-  t.match(serialized.aggregateErrors[1].stack, /^Error: bar/)
-  t.match(serialized.stack, /err\.test\.js:/)
-})
 
 test('serializes Error objects', function (t) {
   t.plan(3)
@@ -194,4 +176,21 @@ test('can wrap err serializers', function (t) {
   t.match(serialized.stack, /err\.test\.js:/)
   t.notOk(serialized.foo)
   t.is(serialized.bar, 'bar')
+})
+
+test('serializes aggregate errors', { skip: !global.AggregateError }, function (t) {
+  t.plan(8)
+  const foo = new Error('foo')
+  const bar = new Error('bar')
+  const aggregate = new AggregateError([foo, bar], 'aggregated message') // eslint-disable-line no-undef
+
+  const serialized = serializer(aggregate)
+  t.equal(serialized.type, 'AggregateError')
+  t.equal(serialized.message, 'aggregated message')
+  t.equal(serialized.aggregateErrors.length, 2)
+  t.equal(serialized.aggregateErrors[0].message, 'foo')
+  t.equal(serialized.aggregateErrors[1].message, 'bar')
+  t.match(serialized.aggregateErrors[0].stack, /^Error: foo/)
+  t.match(serialized.aggregateErrors[1].stack, /^Error: bar/)
+  t.match(serialized.stack, /err\.test\.js:/)
 })

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -194,19 +194,3 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, function (
   t.match(serialized.aggregateErrors[1].stack, /^Error: bar/)
   t.match(serialized.stack, /err\.test\.js:/)
 })
-
-test('avoid infinite recursion in aggregate errors', { skip: !global.AggregateError }, function (t) {
-  t.plan(7)
-  const foo = new Error('foo')
-  const agg1 = new AggregateError([foo], 'aggregated message') // eslint-disable-line no-undef
-  agg1.inner = agg1
-
-  const serialized = serializer(agg1)
-  t.equal(serialized.type, 'AggregateError')
-  t.equal(serialized.message, 'aggregated message')
-  t.equal(serialized.aggregateErrors.length, 1)
-  t.equal(serialized.aggregateErrors[0].message, 'foo')
-  t.match(serialized.aggregateErrors[0].stack, /^Error: foo/)
-  t.match(serialized.stack, /err\.test\.js:/)
-  t.notOk(serialized.inner)
-})

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const { test, skip } = require('tap')
+const test = require('tap').test
 const serializer = require('../lib/err')
 const wrapErrorSerializer = require('../').wrapErrorSerializer
+const hasAggregateError = !!global.AggregateError
 
-test('serializes aggregate errors', function (t) {
-  const major = Number(process.versions.node.split('.')[0])
-  if (major < 15) return skip()
-
+test('serializes aggregate errors', { skip: !hasAggregateError }, function (t) {
   t.plan(8)
   const foo = new Error('foo')
   const bar = new Error('bar')


### PR DESCRIPTION
Example

```js
const log = require('pino')()
const foo = new Error('foo')
const bar = new Error('bar')
const aggregate = new AggregateError([foo, bar], 'aggregated message')
log.error(aggregate)
```

Produces the following serialized output:
```json
{
  "level": 50,
  "time": 1641313649352,
  "pid": 1788,
  "hostname": "SAMEER",
  "err": {
    "type": "AggregateError",
    "message": "aggregated message",
    "stack": "AggregateError: aggregated message\n at Object.<anonymous> (pino-std-serializers\\example.js:12:19)\n at Module._compile (node:internal/modules/cjs/loader:1108:14)\n at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)\n at Module.load (node:internal/modules/cjs/loader:988:32)\n at Function.Module._load (node:internal/modules/cjs/loader:828:14)\n at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)\n at node:internal/main/run_main_module:17:47",
    "aggregateErrors": [
      {
        "type": "Error",
        "message": "foo",
        "stack": "Error: foo\n at Object.<anonymous> (pino-std-serializers\\example.js:10:15)\n at Module._compile (node:internal/modules/cjs/loader:1108:14)\n at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)\n at Module.load (node:internal/modules/cjs/loader:988:32)\n at Function.Module._load (node:internal/modules/cjs/loader:828:14)\n at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)\n at node:internal/main/run_main_module:17:47"
      },
      {
        "type": "Error",
        "message": "bar",
        "stack": "Error: bar\n at Object.<anonymous> (pino-std-serializers\\example.js:11:15)\n at Module._compile (node:internal/modules/cjs/loader:1108:14)\n at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)\n at Module.load (node:internal/modules/cjs/loader:988:32)\n at Function.Module._load (node:internal/modules/cjs/loader:828:14)\n at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)\n at node:internal/main/run_main_module:17:47"
      }
    ]
  },
  "msg": "aggregated message"
}
```

*Note: AggregateError is only supported by node 15+*

Closes #86 