### PR TITLE
Fix restify (#88) by only using req.path if a string

### DIFF
--- a/lib/req.js
+++ b/lib/req.js
@@ -73,12 +73,10 @@ function reqSerializer (req) {
     _req.url = req.originalUrl
     _req.query = req.query
     _req.params = req.params
-  } else if (req.path) {
-    // req.path is to make hapi safe with invalid paths.  req.path() is for restify compat.
-    _req.url = typeof req.path === 'function' ? req.path() : req.path
   } else {
-    // req.url.path is  for hapi compat.
-    _req.url = req.url ? (req.url.path || req.url) : undefined
+    const path = req.path
+    // path for safe hapi compat.
+    _req.url = typeof path === 'string' ? path : (req.url.path || req.url)
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/lib/req.js
+++ b/lib/req.js
@@ -73,9 +73,12 @@ function reqSerializer (req) {
     _req.url = req.originalUrl
     _req.query = req.query
     _req.params = req.params
+  } else if (req.path) {
+    // req.path is to make hapi safe with invalid paths.  req.path() is for restify compat.
+    _req.url = typeof req.path === 'function' ? req.path() : req.path
   } else {
     // req.url.path is  for hapi compat.
-    _req.url = req.path || (req.url ? (req.url.path || req.url) : undefined)
+    _req.url = req.url ? (req.url.path || req.url) : undefined
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/lib/req.js
+++ b/lib/req.js
@@ -76,7 +76,7 @@ function reqSerializer (req) {
   } else {
     const path = req.path
     // path for safe hapi compat.
-    _req.url = typeof path === 'string' ? path : (req.url.path || req.url)
+    _req.url = typeof path === 'string' ? path : (req.url ? req.url.path || req.url : undefined)
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -252,7 +252,7 @@ test('req.url will be obtained from input request originalUrl when available', f
   }
 })
 
-test('req.url will be obtained from input request path() when a function', function (t) {
+test('req.url will be obtained from input request url when req path is a function', function (t) {
   t.plan(1)
 
   const server = http.createServer(handler)
@@ -265,8 +265,9 @@ test('req.url will be obtained from input request path() when a function', funct
 
   function handler (req, res) {
     req.path = function () {
-      return '/test'
+      throw new Error('unexpected invocation')
     }
+    req.url = '/test'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.url, '/test')
     res.end()

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -252,6 +252,27 @@ test('req.url will be obtained from input request originalUrl when available', f
   }
 })
 
+test('req.url will be obtained from input request path() when a function', function (t) {
+  t.plan(1)
+
+  const server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.teardown(() => server.close())
+
+  function handler (req, res) {
+    req.path = function () {
+      return '/test'
+    }
+    const serialized = serializers.reqSerializer(req)
+    t.equal(serialized.url, '/test')
+    res.end()
+  }
+})
+
 test('can wrap request serializers', function (t) {
   t.plan(3)
 

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -274,6 +274,25 @@ test('req.url will be obtained from input request url when req path is a functio
   }
 })
 
+test('req.url being undefined does not throw an error', function (t) {
+  t.plan(1)
+
+  const server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.teardown(() => server.close())
+
+  function handler (req, res) {
+    req.url = undefined
+    const serialized = serializers.reqSerializer(req)
+    t.equal(serialized.url, undefined)
+    res.end()
+  }
+})
+
 test('can wrap request serializers', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
only use `req.path` if it is a string. this is for restify compatibility; fixes #88.

in #29 we preferred `req.path`, because `req.url` would throw in hapi if the path was invalid.
in restify though, [`req.path` is a function](https://github.com/restify/node-restify/blob/5c7eb95319aa54ef3b4b60d000d434824a666e18/lib/request.js#L357) (which returns a parsed url object). so after #29, restify stopped logging url.

in this pr, we check `req.path` to see if it is a string before using it. else we go back to using `req.url`. alternatively, we could have checked if path was a function, then checked if the object returned had a path element, but simply being more specific about what `req.path`'s we accept was preferred as it reduced the amount of branches the code would take.

i have also added a check for `req.url` being undefined, as i nearly hadn't considered that case & almost left the code in a broken/error-throwing state then.

## req.url.path

side discussion- we could possibly simplify more, see https://github.com/rektide/pino-std-serializers/pull/2 which i am happy to do.

right now, this pr still leaves in an [attempt to use `req.url.path`](https://github.com/pinojs/pino-std-serializers/pull/89/files#diff-2c4782cb20f7f0d7ca90c7bc04939f4420c4bdb42fdce618984da393ba9202f7R79), which was [introduced to support hapi](https://github.com/pinojs/pino-std-serializers/commit/63876ff3aa58c2e265a0957830afea04a0637ce0) a number of years ago. since we now use `req.path` to better/more-safely support hapi (as of #29), we could consider removing `req.url.path` checking: these old checks are redunant. hapi has supported `req.path` since before 2013's [v1.0.0](https://github.com/hapijs/hapi/blob/v1.0.0/lib/request.js#L128) so no risk there.

yet there may be people in the world other than hapi who have grown to expect `req.url.path`. i tend to doubt that, and it's tempting to accept that risk & simplify/drop the `req.url.path` check, but i have left it intact for now. happy to do whatever folks want.
