### PR TITLE
Include req.params and req.query when available

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,8 @@ The default `request` serializer. Returns and object:
                 // the value filled.
   method: 'string',
   url: 'string', // the request pathname (as per req.url in core HTTP)
+  query: 'object', // the request query (as per req.query in express or hapi)
+  params: 'object', // the request params (as per req.params in express or hapi)
   headers: Object, // a reference to the `headers` object from the request
                    // (as per req.headers in core HTTP)
   remoteAddress: 'string',

--- a/lib/req.js
+++ b/lib/req.js
@@ -71,13 +71,20 @@ function reqSerializer (req) {
   // req.originalUrl is for expressjs compat.
   if (req.originalUrl) {
     _req.url = req.originalUrl
-    _req.query = req.query
-    _req.params = req.params
   } else {
     const path = req.path
     // path for safe hapi compat.
     _req.url = typeof path === 'string' ? path : (req.url ? req.url.path || req.url : undefined)
   }
+
+  if (req.query) {
+    _req.query = req.query
+  }
+
+  if (req.params) {
+    _req.params = req.params
+  }
+
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress
   _req.remotePort = connection && connection.remotePort

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -406,7 +406,6 @@ test('req.query is available', function (t) {
   t.teardown(() => server.close())
 
   function handler (req, res) {
-    req.originalUrl = '/test'
     req.query = '/foo?bar=foobar&bar=foo'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.query, '/foo?bar=foobar&bar=foo')
@@ -426,7 +425,6 @@ test('req.params is available', function (t) {
   t.teardown(() => server.close())
 
   function handler (req, res) {
-    req.originalUrl = '/test'
     req.params = '/foo/bar'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.params, '/foo/bar')


### PR DESCRIPTION
Presently `req.params` and `req.query` are only included for express. These changes add support for those properties in similar frameworks such as hapi.