### PR TITLE
Serialize errors with cause

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -28,6 +28,11 @@ const pinoErrProto = Object.create({}, {
     writable: true,
     value: undefined
   },
+  cause: {
+    enumerable: true,
+    writable: true,
+    value: undefined
+  },
   raw: {
     enumerable: false,
     get: function () {
@@ -58,6 +63,10 @@ function errSerializer (err) {
 
   if (global.AggregateError !== undefined && err instanceof global.AggregateError && Array.isArray(err.errors)) {
     _err.aggregateErrors = err.errors.map(err => errSerializer(err))
+  }
+
+  if (err.cause) {
+    _err.cause = errSerializer(err.cause)
   }
 
   for (const key in err) {

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -194,3 +194,21 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, function (
   t.match(serialized.aggregateErrors[1].stack, /^Error: bar/)
   t.match(serialized.stack, /err\.test\.js:/)
 })
+
+test('serializes causes', function (t) {
+  t.plan(7)
+
+  const foo = new Error('foo')
+  const bar = new Error('bar', { cause: foo })
+
+  const serialized = serializer(bar)
+
+  t.equal(serialized.type, 'Error')
+  t.equal(serialized.message, 'bar: foo') // message serialization already walks cause-chain
+  t.match(serialized.stack, /err\.test\.js:/)
+
+  t.ok(serialized.cause)
+  t.equal(serialized.cause.type, 'Error')
+  t.equal(serialized.cause.message, 'foo')
+  t.match(serialized.cause.stack, /err\.test\.js:/)
+})

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -196,19 +196,25 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, function (
 })
 
 test('serializes causes', function (t) {
-  t.plan(7)
+  t.plan(11)
 
   const bar = new Error('bar')
   bar.cause = new Error('foo')
+  bar.cause.cause = new Error('baz')
 
   const serialized = serializer(bar)
 
   t.equal(serialized.type, 'Error')
-  t.equal(serialized.message, 'bar: foo') // message serialization already walks cause-chain
+  t.equal(serialized.message, 'bar: foo: baz') // message serialization already walks cause-chain
   t.match(serialized.stack, /err\.test\.js:/)
 
   t.ok(serialized.cause)
   t.equal(serialized.cause.type, 'Error')
-  t.equal(serialized.cause.message, 'foo')
+  t.equal(serialized.cause.message, 'foo: baz')
   t.match(serialized.cause.stack, /err\.test\.js:/)
+
+  t.ok(serialized.cause.cause)
+  t.equal(serialized.cause.cause.type, 'Error')
+  t.equal(serialized.cause.cause.message, 'baz')
+  t.match(serialized.cause.cause.stack, /err\.test\.js:/)
 })

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -198,8 +198,8 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, function (
 test('serializes causes', function (t) {
   t.plan(7)
 
-  const foo = new Error('foo')
-  const bar = new Error('bar', { cause: foo })
+  const bar = new Error('bar')
+  bar.cause = new Error('foo')
 
   const serialized = serializer(bar)
 


### PR DESCRIPTION
Related to #76 and #78 which add serialization of `cause` into error messages.

This PR fixes #94 by making sure the chain of causes found in `err.cause` is serialized in full, bringing the final serialized result closer to what is printed by other serializers (e.g. those in the Node.js CLI and browser consoles).