### PR TITLE
Move file specification for test script to .taprc

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,2 @@
+files:
+- test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint-ci": "standard",
-    "test": "tap --no-cov 'test/**/*.test.js'",
-    "test-ci": "tap --cov --no-check-coverage --coverage-report=text 'test/**/*.test.js'",
+    "test": "tap --no-cov",
+    "test-ci": "tap --cov --no-check-coverage --coverage-report=text",
     "test-types": "tsc && tsd"
   },
   "repository": {


### PR DESCRIPTION
This fixes #104 where the glob for picking test files meant that the test script did not work at all on Windows.