### PR TITLE
Never serialize `.cause` Errors, rely on message + stack summary instead

### DIFF
--- a/lib/err-helpers.js
+++ b/lib/err-helpers.js
@@ -12,22 +12,23 @@
 const getErrorCause = (err) => {
   if (!err) return
 
-  const cause = evaluateCause(err.cause)
+  /** @type {unknown} */
+  // @ts-ignore
+  const cause = err.cause
 
-  return cause instanceof Error
-    ? cause
-    : undefined
-}
+  // VError / NError style causes
+  if (typeof cause === 'function') {
+    // @ts-ignore
+    const causeResult = err.cause()
 
-/**
- * @param {unknown|(()=>err)} cause
- * @returns {Error|undefined}
- */
-const evaluateCause = (cause) => {
-  // VError / NError style causes are functions
-  return typeof cause === 'function'
-    ? cause()
-    : cause
+    return causeResult instanceof Error
+      ? causeResult
+      : undefined
+  } else {
+    return cause instanceof Error
+      ? cause
+      : undefined
+  }
 }
 
 /**
@@ -107,7 +108,6 @@ const messageWithCauses = (err) => _messageWithCauses(err, new Set())
 
 module.exports = {
   getErrorCause,
-  evaluateCause,
   stackWithCauses,
   messageWithCauses
 }

--- a/lib/err.js
+++ b/lib/err.js
@@ -63,9 +63,9 @@ function errSerializer (err) {
   for (const key in err) {
     if (_err[key] === undefined) {
       const val = err[key]
-      if (val instanceof Error && key !== 'cause') {
+      if (val instanceof Error) {
         /* eslint-disable no-prototype-builtins */
-        if (!val.hasOwnProperty(seen)) {
+        if (key !== 'cause' && !val.hasOwnProperty(seen)) {
           _err[key] = errSerializer(val)
         }
       } else {

--- a/lib/err.js
+++ b/lib/err.js
@@ -2,7 +2,7 @@
 
 module.exports = errSerializer
 
-const { messageWithCauses, stackWithCauses, evaluateCause } = require('./err-helpers')
+const { messageWithCauses, stackWithCauses } = require('./err-helpers')
 
 const { toString } = Object.prototype
 const seen = Symbol('circular-ref-tag')
@@ -66,8 +66,7 @@ function errSerializer (err) {
   }
 
   if (err.cause) {
-    const cause = evaluateCause(err.cause)
-    _err.cause = errSerializer(cause)
+    _err.cause = errSerializer(err.cause)
   }
 
   for (const key in err) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -28,11 +28,6 @@ const pinoErrProto = Object.create({}, {
     writable: true,
     value: undefined
   },
-  cause: {
-    enumerable: true,
-    writable: true,
-    value: undefined
-  },
   raw: {
     enumerable: false,
     get: function () {
@@ -63,10 +58,6 @@ function errSerializer (err) {
 
   if (global.AggregateError !== undefined && err instanceof global.AggregateError && Array.isArray(err.errors)) {
     _err.aggregateErrors = err.errors.map(err => errSerializer(err))
-  }
-
-  if (err.cause) {
-    _err.cause = errSerializer(err.cause)
   }
 
   for (const key in err) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -64,8 +64,8 @@ function errSerializer (err) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (val instanceof Error) {
-        /* eslint-disable no-prototype-builtins */
-        if (key !== 'cause' && !val.hasOwnProperty(seen)) {
+        // We append cause messages and stacks to _err, therefore skipping causes here
+        if (key !== 'cause' && !Object.prototype.hasOwnProperty.call(val, seen)) {
           _err[key] = errSerializer(val)
         }
       } else {

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -194,27 +194,3 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, function (
   t.match(serialized.aggregateErrors[1].stack, /^Error: bar/)
   t.match(serialized.stack, /err\.test\.js:/)
 })
-
-test('serializes causes', function (t) {
-  t.plan(11)
-
-  const bar = new Error('bar')
-  bar.cause = new Error('foo')
-  bar.cause.cause = new Error('baz')
-
-  const serialized = serializer(bar)
-
-  t.equal(serialized.type, 'Error')
-  t.equal(serialized.message, 'bar: foo: baz') // message serialization already walks cause-chain
-  t.match(serialized.stack, /err\.test\.js:/)
-
-  t.ok(serialized.cause)
-  t.equal(serialized.cause.type, 'Error')
-  t.equal(serialized.cause.message, 'foo: baz')
-  t.match(serialized.cause.stack, /err\.test\.js:/)
-
-  t.ok(serialized.cause.cause)
-  t.equal(serialized.cause.cause.type, 'Error')
-  t.equal(serialized.cause.cause.message, 'baz')
-  t.match(serialized.cause.cause.stack, /err\.test\.js:/)
-})

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -218,31 +218,3 @@ test('serializes causes', function (t) {
   t.equal(serialized.cause.cause.message, 'baz')
   t.match(serialized.cause.cause.stack, /err\.test\.js:/)
 })
-
-test('serializes causes with VError support', function (t) {
-  t.plan(11)
-
-  // Fake VError-style setup
-  const err = Error('foo: bar')
-  err.cause = () => {
-    const err = Error('bar')
-    err.cause = Error('abc')
-    return err
-  }
-
-  const serialized = serializer(err)
-
-  t.equal(serialized.type, 'Error')
-  t.equal(serialized.message, 'foo: bar: abc') // message serialization already walks cause-chain
-  t.match(serialized.stack, /err\.test\.js:/)
-
-  t.ok(serialized.cause)
-  t.equal(serialized.cause.type, 'Error')
-  t.equal(serialized.cause.message, 'bar: abc')
-  t.match(serialized.cause.stack, /err\.test\.js:/)
-
-  t.ok(serialized.cause.cause)
-  t.equal(serialized.cause.cause.type, 'Error')
-  t.equal(serialized.cause.cause.message, 'abc')
-  t.match(serialized.cause.cause.stack, /err\.test\.js:/)
-})


### PR DESCRIPTION
This is an alternative fix to #94, replacing #105 and #108 and in the process make #109 not needed

Builds on my comment here https://github.com/pinojs/pino-std-serializers/pull/105#issuecomment-1153917121

In short:

Doing both a summary of the errors cause chain + serializing all the errors in the cause chain is doing the same thing twice basically.

And when on top of that doing summaries for each cause along the chain as well, then that's triple work.

In https://github.com/pinojs/pino-std-serializers/pull/78/files#diff-71c187d84f435004e68161a25e470d823f4de310a1d39b531cc02a90f3730149R56 I specifically opted out causes from recursion:

```javascript
if (val instanceof Error && key !== 'cause') {
  /* eslint-disable no-prototype-builtins */
  if (!val.hasOwnProperty(seen)) {
```

I think #94 simply reflects that it didn't do what it intended do do, which should have been this:

```javascript
if (val instanceof Error) {
  /* eslint-disable no-prototype-builtins */
  if (key !== 'cause' && !val.hasOwnProperty(seen)) {
```

That way it will exclude all `Error` causes from serialization, as intended, but keeping other causes for increased backwards compatibility.

This PR reverts #105 and #108, then applies the above fix.