### PR TITLE
chore!: drop support for node 10, 12 and 15; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 12, 14, 15, 16]
+        node-version: [14, 16, 18]
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 10, 12 and 15; adds support for node 18