### PR TITLE
[Discussion] Intentional to mask `error.cause`?

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -64,8 +64,7 @@ function errSerializer (err) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (isErrorLike(val)) {
-        // We append cause messages and stacks to _err, therefore skipping causes here
-        if (key !== 'cause' && !Object.prototype.hasOwnProperty.call(val, seen)) {
+        if (!Object.prototype.hasOwnProperty.call(val, seen)) {
           _err[key] = errSerializer(val)
         }
       } else {


### PR DESCRIPTION
Thought it was easier to create a discussion with my proposed change here.

I was debugging some errors in production and noticed that my `cause`-tree was missing and I think I have drilled it down to this line of code.

Often times, libraries wrap errors in their own errors so they are homogenic (we do this in tRPC by wrapping all in `TRPCError` with the original error as the `cause` and Apollo Server does something similar with GraphQL Errors IIRC). 

For debugging however, the original error may contain useful properties, which seem to be hidden here.

I can work around this, but wanted to ask some more motivation on how come this is and if this is intentional? 

It might be me misinterpreting how to use things