### PR TITLE
Add info about `cause` explicitly always being `undefined`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export interface SerializedError {
   /**
    * `cause` is never included in the log output, if you need the `cause`, use {@link raw.cause}
    */
-  cause: undefined;
+  cause?: never;
   /**
    * Any other extra properties that have been attached to the object will also be present on the serialized object.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface SerializedError {
    */
   raw: Error;
   /**
-   * `cause` is never included in the log output, if you need the `cause`, use `raw.cause`
+   * `cause` is never included in the log output, if you need the `cause`, use {@link raw.cause}
    */
   cause: undefined;
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,10 @@ export interface SerializedError {
    */
   raw: Error;
   /**
+   * `cause` is never included in the log output, if you need the `cause`, use `raw.cause`
+   */
+  cause: undefined;
+  /**
    * Any other extra properties that have been attached to the object will also be present on the serialized object.
    */
   [key: string]: any;


### PR DESCRIPTION
## Summary 

Adds info that `cause` is always undefined.

## Motivation
- I was confused, I guess I missed that `[string]: any` and interpreted this as `.cause` being supposed to be set.
  - <img width="724" alt="CleanShot 2023-02-07 at 19 01 55@2x" src="https://user-images.githubusercontent.com/459267/217328824-639a7685-baa9-435c-a856-6472e4223c14.png">
  - https://github.com/pinojs/pino-std-serializers/pull/123
- #110

## Further comments

I am not sure if I agree with the decision to hide it, the original issue (#94), seemed to want explicit handling of `.cause` and not to hide it. It caught me by surprise.