### PR TITLE
Add params and query to ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,9 @@ export interface SerializedRequest {
   headers: Record<string, string>;
   remoteAddress: string;
   remotePort: number;
+  params: Record<string, string>;
+  query: Record<string, string>;
+
   /**
    * Non-enumerable, i.e. will not be in the output, original request object. This is available for subsequent
    * serializers to use. In cases where the `request` input already has  a `raw` property this will

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -21,7 +21,17 @@ const customErrorSerializer = (error: SerializedError) => {
 };
 
 const customRequestSerializer = (req: SerializedRequest) => {
-  const {headers, id, method, raw, remoteAddress, remotePort, url} = req;
+  const {
+    headers,
+    id,
+    method,
+    raw,
+    remoteAddress,
+    remotePort,
+    url,
+    query,
+    params,
+  } = req;
   return {
     myOwnRequest: {
       data: `${method}-${id}-${remoteAddress}-${remotePort}-${url}`,


### PR DESCRIPTION
[params](https://github.com/pinojs/pino-std-serializers/blob/master/lib/req.js#L30) and [query](https://github.com/pinojs/pino-std-serializers/blob/master/lib/req.js#L25) are listed as part of serialized request object but missing in the [SerializedRequest](https://github.com/pinojs/pino-std-serializers/blob/master/index.d.ts#L49) interface