### PR TITLE
Updating for v9: update dependencies and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "test-types"
   ],
   "devDependencies": {
+    "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "tap": "^15.0.10",
+    "tap": "^16.3.9",
     "tsd": "^0.29.0",
     "typescript": "^5.0.2"
   },


### PR DESCRIPTION
Hello everyone!

As needed in [issue #1762](https://github.com/pinojs/pino/issues/1762) and referenced [here](https://github.com/pinojs/pino-http/issues/299) this pr is needed for pino v9.

I did not open an issue related but I will if needed, and I merged both CI and dependencies update, if you think it's better to provide two separate pr, I'll split them as well.

Thank you in advance!

@jsumners 