### PR TITLE
docs(readme): add missing code block quotes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,7 @@ const serialized = serializer(outerError);
         at <...omitted..>
 }
  */
+```
 
 ### `exports.errWithCause(error)`
 Serializes an `Error` like object, including any `error.cause`. Returns an object:


### PR DESCRIPTION
Readme.md markdown around the `exports.errWithCause(error)` documentation is rendering wrong because the previous code block is not closed