### PR TITLE
feat: Support serializing primitives within Error causes (#158)

### DIFF
--- a/lib/err-helpers.js
+++ b/lib/err-helpers.js
@@ -29,9 +29,7 @@ const getErrorCause = (err) => {
       ? causeResult
       : undefined
   } else {
-    return isErrorLike(cause)
-      ? cause
-      : undefined
+    return cause
   }
 }
 
@@ -44,8 +42,6 @@ const getErrorCause = (err) => {
  * @returns {string}
  */
 const _stackWithCauses = (err, seen) => {
-  if (!isErrorLike(err)) return ''
-
   const stack = err.stack || ''
 
   // Ensure we don't go circular or crazily deep
@@ -56,8 +52,12 @@ const _stackWithCauses = (err, seen) => {
   const cause = getErrorCause(err)
 
   if (cause) {
-    seen.add(err)
-    return (stack + '\ncaused by: ' + _stackWithCauses(cause, seen))
+    if (isErrorLike(cause)) {
+      seen.add(err)
+      return (stack + '\ncaused by: ' + _stackWithCauses(cause, seen))
+    } else {
+      return (stack + '\ncaused by: ' + String(cause))
+    }
   } else {
     return stack
   }
@@ -79,8 +79,6 @@ const stackWithCauses = (err) => _stackWithCauses(err, new Set())
  * @returns {string}
  */
 const _messageWithCauses = (err, seen, skip) => {
-  if (!isErrorLike(err)) return ''
-
   const message = skip ? '' : (err.message || '')
 
   // Ensure we don't go circular or crazily deep
@@ -91,14 +89,18 @@ const _messageWithCauses = (err, seen, skip) => {
   const cause = getErrorCause(err)
 
   if (cause) {
-    seen.add(err)
-
     // @ts-ignore
     const skipIfVErrorStyleCause = typeof err.cause === 'function'
 
-    return (message +
-      (skipIfVErrorStyleCause ? '' : ': ') +
-      _messageWithCauses(cause, seen, skipIfVErrorStyleCause))
+    if (isErrorLike(cause)) {
+      seen.add(err)
+
+      return (message +
+        (skipIfVErrorStyleCause ? '' : ': ') +
+        _messageWithCauses(cause, seen, skipIfVErrorStyleCause))
+    } else {
+      return (message + (skipIfVErrorStyleCause ? '' : ': ') + String(cause))
+    }
   } else {
     return message
   }

--- a/lib/err-with-cause.js
+++ b/lib/err-with-cause.js
@@ -25,7 +25,7 @@ function errWithCauseSerializer (err) {
     _err.aggregateErrors = err.errors.map(err => errWithCauseSerializer(err))
   }
 
-  if (isErrorLike(err.cause) && !Object.prototype.hasOwnProperty.call(err.cause, seen)) {
+  if (err.cause !== undefined && !Object.prototype.hasOwnProperty.call(err.cause, seen)) {
     _err.cause = errWithCauseSerializer(err.cause)
   }
 

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -75,6 +75,24 @@ test('keeps non-error cause', () => {
   assert.strictEqual(serialized.cause, 'abc')
 })
 
+test('keeps non-error cause from constructor', () => {
+  for (const cause of [
+    'string',
+    42,
+    ['an', 'array'],
+    ['a', ['nested', 'array']],
+    { an: 'object' },
+    { a: { nested: 'object' } },
+    Symbol('symbol')
+  ]) {
+    const err = Error('foo', { cause })
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.strictEqual(serialized.cause, cause)
+  }
+})
+
 test('prevents infinite recursion', () => {
   const err = Error('foo')
   err.inner = err

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -62,6 +62,25 @@ test('serializes error causes', () => {
   }
 })
 
+test('serializes non Error error cause from constructor', () => {
+  for (const cause of [
+    'string',
+    42,
+    // ['an', 'array'],
+    // ['a', ['nested', 'array']],
+    // { an: 'object' },
+    // { a: { nested: 'object' } },
+    Symbol('symbol')
+  ]) {
+    const err = Error('foo', { cause })
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo: ' + String(cause))
+    assert.match(serialized.stack, /err\.test\.js:/)
+    assert.match(serialized.stack, /Error: foo/)
+  }
+})
+
 test('serializes error causes with VError support', function (t) {
   // Fake VError-style setup
   const err = Error('foo: bar')
@@ -85,7 +104,7 @@ test('keeps non-error cause', () => {
   err.cause = 'abc'
   const serialized = serializer(err)
   assert.strictEqual(serialized.type, 'Error')
-  assert.strictEqual(serialized.message, 'foo')
+  assert.strictEqual(serialized.message, 'foo: abc')
   assert.strictEqual(serialized.cause, 'abc')
 })
 


### PR DESCRIPTION
Allow primitives to be returned as error causes when passed via the ErrorOptions object in an [Error object constructor](https://github.com/microsoft/TypeScript/blob/main/src/lib/es2022.error.d.ts#L11-L13).