### PR TITLE
Avoid inherited error properties in serializers

### DIFF
--- a/lib/err-with-cause.js
+++ b/lib/err-with-cause.js
@@ -29,7 +29,7 @@ function errWithCauseSerializer (err) {
     _err.cause = errWithCauseSerializer(err.cause)
   }
 
-  for (const key in err) {
+  for (const key of Object.keys(err)) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (isErrorLike(val)) {

--- a/lib/err.js
+++ b/lib/err.js
@@ -25,7 +25,7 @@ function errSerializer (err) {
     _err.aggregateErrors = err.errors.map(err => errSerializer(err))
   }
 
-  for (const key in err) {
+  for (const key of Object.keys(err)) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (isErrorLike(val)) {

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -23,6 +23,18 @@ test('serializes Error objects with extra properties', () => {
   assert.match(serialized.stack, /err-with-cause\.test\.js:/)
 })
 
+test('does not serialize inherited enumerable properties', () => {
+  class ProtoError extends Error {}
+  ProtoError.prototype.protoValue = 'proto'
+
+  const err = new ProtoError('foo')
+  err.ownValue = 'own'
+
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.ownValue, 'own')
+  assert.ok(!Object.prototype.hasOwnProperty.call(serialized, 'protoValue'))
+})
+
 test('serializes Error objects with subclass "type"', () => {
   class MyError extends Error {}
 

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -23,6 +23,18 @@ test('serializes Error objects with extra properties', () => {
   assert.match(serialized.stack, /err\.test\.js:/)
 })
 
+test('does not serialize inherited enumerable properties', () => {
+  class ProtoError extends Error {}
+  ProtoError.prototype.protoValue = 'proto'
+
+  const err = new ProtoError('foo')
+  err.ownValue = 'own'
+
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.ownValue, 'own')
+  assert.ok(!Object.prototype.hasOwnProperty.call(serialized, 'protoValue'))
+})
+
 test('serializes Error objects with subclass "type"', () => {
   class MyError extends Error {}
   const err = new MyError('foo')


### PR DESCRIPTION
## Summary
- iterate over own enumerable error properties only to avoid inherited noise
- add regression coverage for inherited enumerable properties

## Testing
- npm test