### PR TITLE
feat: respect toJSON() on Error class prototypes

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -13,6 +13,37 @@ function errSerializer (err) {
     return err
   }
 
+  // Check if error has a toJSON method and use it if available
+  if (typeof err.toJSON === 'function') {
+    const json = err.toJSON()
+
+    // Ensure essential fields are present
+    if (json.type === undefined) {
+      json.type = toString.call(err.constructor) === '[object Function]'
+        ? err.constructor.name
+        : err.name
+    }
+    if (json.message === undefined) {
+      json.message = messageWithCauses(err)
+    }
+    if (json.stack === undefined) {
+      json.stack = stackWithCauses(err)
+    }
+
+    // When toJSON() is defined, trust it to control serialization.
+    // However, we still want to include nested errors (like err.errors array).
+    // Only add properties that the error author explicitly included in toJSON output
+    // OR are necessary for error structure (like errors array for AggregateError).
+
+    // If the error has an errors array (AggregateError pattern), serialize it
+    if (Array.isArray(err.errors)) {
+      json.aggregateErrors = err.errors.map(e => errSerializer(e))
+    }
+
+    json.raw = err
+    return json
+  }
+
   err[seen] = undefined // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
   _err.type = toString.call(err.constructor) === '[object Function]'

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -198,3 +198,111 @@ test('serializes aggregate errors', { skip: !global.AggregateError }, () => {
     assert.match(serialized.stack, /err\.test\.js:/)
   }
 })
+
+test('uses toJSON() from class prototype', () => {
+  class MyError extends Error {
+    constructor (message) {
+      super(message)
+      this.name = 'MyError'
+      this.largeData = { data: 'x'.repeat(10000) }
+    }
+
+    toJSON () {
+      return { message: this.message, name: this.name }
+    }
+  }
+
+  const err = new MyError('test')
+  const serialized = serializer(err)
+
+  // toJSON() should be respected, so largeData should not be present
+  assert.ok(!('largeData' in serialized))
+  assert.strictEqual(serialized.message, 'test')
+  assert.strictEqual(serialized.name, 'MyError')
+  assert.ok(serialized.stack) // stack should still be added by serializer
+  assert.strictEqual(serialized.type, 'MyError') // type should be added
+  assert.strictEqual(serialized.raw, err) // raw should be present
+})
+
+test('uses toJSON() with custom type when toJSON returns partial data', () => {
+  class MyError extends Error {
+    constructor (message) {
+      super(message)
+      this.name = 'MyError'
+      this.customField = 'custom'
+    }
+
+    toJSON () {
+      return { message: this.message } // doesn't include type
+    }
+  }
+
+  const err = new MyError('test')
+  const serialized = serializer(err)
+
+  // type should be added by serializer if not present in toJSON output
+  assert.strictEqual(serialized.type, 'MyError')
+  assert.strictEqual(serialized.message, 'test')
+  assert.ok(serialized.stack)
+})
+
+test('uses toJSON() from own property (legacy behavior)', () => {
+  const err = Error('test')
+  err.customField = 'value'
+  err.toJSON = function () {
+    return { message: this.message, customField: this.customField }
+  }
+
+  const serialized = serializer(err)
+
+  assert.strictEqual(serialized.message, 'test')
+  assert.strictEqual(serialized.customField, 'value')
+  assert.ok(serialized.stack) // stack should still be added
+  assert.strictEqual(serialized.type, 'Error') // type should be added
+})
+
+test('uses toJSON() with error causes', () => {
+  class MyError extends Error {
+    constructor (message, cause) {
+      super(message, { cause })
+      this.name = 'MyError'
+      this.cause = cause
+    }
+
+    toJSON () {
+      return { message: this.message, name: this.name }
+    }
+  }
+
+  const cause = new Error('cause')
+  const err = new MyError('test', cause)
+  const serialized = serializer(err)
+
+  // toJSON() should be used, cause message should be included in message via messageWithCauses
+  assert.ok(!('cause' in serialized))
+  assert.match(serialized.message, /test/)
+  assert.strictEqual(serialized.name, 'MyError')
+})
+
+test('uses toJSON() - custom fields not added if not in toJSON output', () => {
+  class MyError extends Error {
+    constructor (message) {
+      super(message)
+      this.name = 'MyError'
+      this.customField = 'value'
+    }
+
+    toJSON () {
+      return { message: 'overridden' } // intentionally excludes customField
+    }
+  }
+
+  const err = new MyError('test')
+  const serialized = serializer(err)
+
+  // toJSON() controls serialization - customField should NOT be added
+  assert.strictEqual(serialized.message, 'overridden')
+  assert.ok(!('customField' in serialized)) // intentionally excluded
+  assert.ok(serialized.stack) // stack should still be added
+  assert.strictEqual(serialized.type, 'MyError') // type should be added
+})


### PR DESCRIPTION
Fixes #194

## Problem

The error serializer was not respecting `toJSON()` methods defined on Error class prototypes. This caused issues with libraries like Axios v1.13.3+ which refactored `AxiosError` from a function-based constructor to an ES6 class, moving `toJSON()` from an own property to the prototype.

When `toJSON()` is on the prototype, it's non-enumerable and not copied by the serializer's `for...in` loop. This causes `JSON.stringify()` to not use the custom `toJSON()`, leading to serialization of large properties (like `response.data`) that should be excluded.

## Solution

Check for `toJSON()` method before property enumeration:

1. If `toJSON()` exists and is callable, invoke it
2. Merge essential fields (`type`, `message`, `stack`) if missing from toJSON output
3. Trust `toJSON()` output - properties intentionally excluded are not added back
4. Special handling for `AggregateError` pattern (serialize `errors` array)
5. Preserve `raw` property pointing to the original error

## Testing

Added 5 new test cases:
- `uses toJSON() from class prototype` - ES6 class with `toJSON()` on prototype
- `uses toJSON() with custom type when toJSON returns partial data` - type field addition
- `uses toJSON() from own property (legacy behavior)` - backward compatibility
- `uses toJSON() with error causes` - interaction with error causes
- `uses toJSON() - custom fields not added if not in toJSON output` - trust in toJSON()

All tests pass, including existing error serializer tests.
