### PR TITLE
Serialize non-error `cause`

### DIFF
--- a/lib/err-helpers.js
+++ b/lib/err-helpers.js
@@ -10,29 +10,13 @@ const isErrorLike = (err) => {
 }
 
 /**
- * @param {Error|{ cause?: unknown|(()=>err)}} err
- * @returns {Error|Object|undefined}
+ * @param {Error|{ cause?: unknown|(()=>unknown)}} err
+ * @returns {unknown}
  */
 const getErrorCause = (err) => {
   if (!err) return
 
-  /** @type {unknown} */
-  // @ts-ignore
-  const cause = err.cause
-
-  // VError / NError style causes
-  if (typeof cause === 'function') {
-    // @ts-ignore
-    const causeResult = err.cause()
-
-    return isErrorLike(causeResult)
-      ? causeResult
-      : undefined
-  } else {
-    return isErrorLike(cause)
-      ? cause
-      : undefined
-  }
+  return typeof err.cause === 'function' ? err.cause() : err.cause
 }
 
 /**
@@ -44,9 +28,9 @@ const getErrorCause = (err) => {
  * @returns {string}
  */
 const _stackWithCauses = (err, seen) => {
-  if (!isErrorLike(err)) return ''
+  if (!isErrorLike(err)) return err
 
-  const stack = err.stack || ''
+  const stack = err.stack || err.message || ''
 
   // Ensure we don't go circular or crazily deep
   if (seen.has(err)) {
@@ -79,7 +63,7 @@ const stackWithCauses = (err) => _stackWithCauses(err, new Set())
  * @returns {string}
  */
 const _messageWithCauses = (err, seen, skip) => {
-  if (!isErrorLike(err)) return ''
+  if (!isErrorLike(err)) return err
 
   const message = skip ? '' : (err.message || '')
 

--- a/lib/err-with-cause.js
+++ b/lib/err-with-cause.js
@@ -2,11 +2,16 @@
 
 module.exports = errWithCauseSerializer
 
-const { isErrorLike } = require('./err-helpers')
+const { isErrorLike, getErrorCause } = require('./err-helpers')
 const { pinoErrProto, pinoErrorSymbols } = require('./err-proto')
 const { seen } = pinoErrorSymbols
 
 const { toString } = Object.prototype
+
+const skippedOwnProps = new Set([
+  'constructor',
+  'cause', // Serialised on demand as `cause` property set via constructor is non-enumerable.
+])
 
 function errWithCauseSerializer (err) {
   if (!isErrorLike(err)) {
@@ -25,21 +30,17 @@ function errWithCauseSerializer (err) {
     _err.aggregateErrors = err.errors.map(err => errWithCauseSerializer(err))
   }
 
-  if (isErrorLike(err.cause) && !Object.prototype.hasOwnProperty.call(err.cause, seen)) {
-    _err.cause = errWithCauseSerializer(err.cause)
+  for (const key in err) {
+    const val = err[key]
+    if (val === undefined || val === null || Object.prototype.hasOwnProperty.call(val, seen) || skippedOwnProps.has(key)) {
+      continue
+    }
+    _err[key] = errWithCauseSerializer(val)
   }
 
-  for (const key in err) {
-    if (_err[key] === undefined) {
-      const val = err[key]
-      if (isErrorLike(val)) {
-        if (!Object.prototype.hasOwnProperty.call(val, seen)) {
-          _err[key] = errWithCauseSerializer(val)
-        }
-      } else {
-        _err[key] = val
-      }
-    }
+  const cause = getErrorCause(err)
+  if (cause !== undefined || Object.prototype.hasOwnProperty.call(err, seen)) {
+    _err.cause = errWithCauseSerializer(cause)
   }
 
   delete err[seen] // clean up tag in case err is serialized again later

--- a/lib/err.js
+++ b/lib/err.js
@@ -8,6 +8,11 @@ const { seen } = pinoErrorSymbols
 
 const { toString } = Object.prototype
 
+const skippedOwnProps = new Set([
+  'constructor',
+  'cause', // Serialised on demand as `cause` property set via constructor is non-enumerable.
+])
+
 function errSerializer (err) {
   if (!isErrorLike(err)) {
     return err
@@ -52,22 +57,22 @@ function errSerializer (err) {
   _err.message = messageWithCauses(err)
   _err.stack = stackWithCauses(err)
 
+  // This really is not serialised and contradicts docs and SerializedError typings.
+  // It was made available by accident in some cases (captured in the for/in loop, when setting err.cause property directly)
+  // It is used by underlying serialisers but really _err.raw.cause should be used instead.
+  _err.cause = err.cause
+
   if (Array.isArray(err.errors)) {
     _err.aggregateErrors = err.errors.map(err => errSerializer(err))
   }
 
   for (const key in err) {
-    if (_err[key] === undefined) {
-      const val = err[key]
-      if (isErrorLike(val)) {
-        // We append cause messages and stacks to _err, therefore skipping causes here
-        if (key !== 'cause' && !Object.prototype.hasOwnProperty.call(val, seen)) {
-          _err[key] = errSerializer(val)
-        }
-      } else {
-        _err[key] = val
-      }
+    const val = err[key]
+    if (val === undefined || val === null || Object.prototype.hasOwnProperty.call(val, seen) || skippedOwnProps.has(key)) {
+      continue
     }
+
+    _err[key] = errSerializer(val)
   }
 
   delete err[seen] // clean up tag in case err is serialized again later

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -88,12 +88,21 @@ test('keeps error cause', () => {
 })
 
 test('keeps non-error cause', () => {
-  const err = Error('foo')
-  err.cause = 'abc'
-  const serialized = serializer(err)
-  assert.strictEqual(serialized.type, 'Error')
-  assert.strictEqual(serialized.message, 'foo')
-  assert.strictEqual(serialized.cause, 'abc')
+  {
+    const err = Error('foo')
+    err.cause = 'abc'
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.strictEqual(serialized.cause, 'abc')
+  }
+  {
+    const err = Error('foo', { cause: 'abc' })
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.strictEqual(serialized.cause, 'abc') // fails here
+  }
 })
 
 test('prevents infinite recursion', () => {

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -66,6 +66,27 @@ test('serializes error causes', () => {
   assert.match(serialized.cause.cause.stack, /err-with-cause\.test\.js:/)
 })
 
+test('keeps error cause', () => {
+  const table = [
+    [Error('bar'), 'bar'],
+    [{ message: 'baz' }, 'baz'],
+  ];
+  
+  for (const [cause, expectedMessage] of table) {
+    {
+      const err = Error('foo', { cause: cause });
+      const serialized = serializer(err)
+      assert.strictEqual(serialized.cause.message, expectedMessage)
+    }
+    {
+      const err = Error('foo')
+      err.cause = cause
+      const serialized = serializer(err)
+      assert.strictEqual(serialized.cause.message, expectedMessage)
+    }
+  }
+})
+
 test('keeps non-error cause', () => {
   const err = Error('foo')
   err.cause = 'abc'

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -70,11 +70,11 @@ test('keeps error cause', () => {
   const table = [
     [Error('bar'), 'bar'],
     [{ message: 'baz' }, 'baz'],
-  ];
-  
+  ]
+
   for (const [cause, expectedMessage] of table) {
     {
-      const err = Error('foo', { cause: cause });
+      const err = Error('foo', { cause })
       const serialized = serializer(err)
       assert.strictEqual(serialized.cause.message, expectedMessage)
     }
@@ -101,7 +101,7 @@ test('keeps non-error cause', () => {
     const serialized = serializer(err)
     assert.strictEqual(serialized.type, 'Error')
     assert.strictEqual(serialized.message, 'foo')
-    assert.strictEqual(serialized.cause, 'abc') // fails here
+    assert.strictEqual(serialized.cause, 'abc')
   }
 })
 

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -55,9 +55,7 @@ test('serializes error causes', () => {
     assert.strictEqual(serialized.type, 'Error')
     assert.strictEqual(serialized.message, 'foo: bar: abc')
     assert.match(serialized.stack, /err\.test\.js:/)
-    assert.match(serialized.stack, /Error: foo/)
-    assert.match(serialized.stack, /Error: bar/)
-    assert.match(serialized.stack, /Error: abc/)
+    assert.match(serialized.stack, /Error: foo[\s\S]*?caused by: Error: bar[\s\S]*?caused by: Error: abc/)
     assert.ok(!serialized.cause)
   }
 })
@@ -75,9 +73,7 @@ test('serializes error causes with VError support', function (t) {
   assert.strictEqual(serialized.type, 'Error')
   assert.strictEqual(serialized.message, 'foo: bar: abc')
   assert.match(serialized.stack, /err\.test\.js:/)
-  assert.match(serialized.stack, /Error: foo/)
-  assert.match(serialized.stack, /Error: bar/)
-  assert.match(serialized.stack, /Error: abc/)
+  assert.match(serialized.stack, /Error: foo: bar[\s\S]*?caused by: Error: bar[\s\S]*?caused by: Error: abc/)
 })
 
 test('keeps non-error cause', () => {

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -56,7 +56,6 @@ test('serializes error causes', () => {
     assert.strictEqual(serialized.message, 'foo: bar: abc')
     assert.match(serialized.stack, /err\.test\.js:/)
     assert.match(serialized.stack, /Error: foo[\s\S]*?caused by: Error: bar[\s\S]*?caused by: Error: abc/)
-    assert.ok(!serialized.cause)
   }
 })
 
@@ -79,18 +78,29 @@ test('serializes error causes with VError support', function (t) {
 test('keeps non-error cause', () => {
   {
     const err = Error('foo')
-    err.cause = 'abc'
+    err.cause = 'bar'
     const serialized = serializer(err)
     assert.strictEqual(serialized.type, 'Error')
-    assert.strictEqual(serialized.message, 'foo')
-    assert.strictEqual(serialized.cause, 'abc')
+    assert.strictEqual(serialized.message, 'foo: bar')
+    assert.strictEqual(serialized.cause, 'bar')
+    assert.match(serialized.stack, /Error: foo[\s\S]*?caused by: bar/)
   }
   {
-    const err = Error('foo', { cause: 'abc' })
+    const err = Error('foo', { cause: 'bar' })
     const serialized = serializer(err)
     assert.strictEqual(serialized.type, 'Error')
-    assert.strictEqual(serialized.message, 'foo')
-    assert.strictEqual(serialized.cause, 'abc') // fails here
+    assert.strictEqual(serialized.message, 'foo: bar')
+    assert.strictEqual(serialized.cause, 'bar')
+    assert.match(serialized.stack, /Error: foo[\s\S]*?caused by: bar/)
+  }
+  {
+    const err = Error('foo', { cause: { message: 'bar', cause: 'baz' } })
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo: bar: baz')
+    assert.strictEqual(serialized.cause.message, 'bar')
+    assert.strictEqual(serialized.cause.cause, 'baz')
+    assert.match(serialized.stack, /Error: foo[\s\S]*?caused by: bar[\s\S]*?caused by: baz/)
   }
 })
 
@@ -287,6 +297,7 @@ test('uses toJSON() with error causes', () => {
   assert.ok(!('cause' in serialized))
   assert.match(serialized.message, /test/)
   assert.strictEqual(serialized.name, 'MyError')
+  assert.match(serialized.stack, /MyError: test[\s\S]*?caused by: Error: cause/)
 })
 
 test('uses toJSON() - custom fields not added if not in toJSON output', () => {

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -77,12 +77,21 @@ test('serializes error causes with VError support', function (t) {
 })
 
 test('keeps non-error cause', () => {
-  const err = Error('foo')
-  err.cause = 'abc'
-  const serialized = serializer(err)
-  assert.strictEqual(serialized.type, 'Error')
-  assert.strictEqual(serialized.message, 'foo')
-  assert.strictEqual(serialized.cause, 'abc')
+  {
+    const err = Error('foo')
+    err.cause = 'abc'
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.strictEqual(serialized.cause, 'abc')
+  }
+  {
+    const err = Error('foo', { cause: 'abc' })
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.strictEqual(serialized.cause, 'abc') // fails here
+  }
 })
 
 test('prevents infinite recursion', () => {


### PR DESCRIPTION
**Issues:**
- The non-error `cause` property set via constructor is not retained.
- The non-error "cause" is not included in the stack

**Why is that happening:**
- Serializers have logic that only allows error like "cause", while runtime is very permissive (in fact, it's typed as `{ cause?: unknown }`
- In addition the `cause` property set via the constructor is non-enumerable. The serializers were primarily using a for...in loop to find extra properties, which skips non-enumerable ones.

**Why the change:**
- while one should not, it's possible to `throw 42`
- but it perfectly ok to `Promise.reject(42)`
- it partially supported by the lib (via `err.cause = 42`, but not via `Error('ooops', { cause: 42 })`)

I really hope per commit "evolution" helps in review process.