### PR TITLE
fix: serialize SuppressedError error and suppressed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,14 @@ export interface SerializedError {
    */
   cause?: never;
   /**
+   * The serialized `error` property of a `SuppressedError`, when present.
+   */
+  error?: SerializedError;
+  /**
+   * The serialized `suppressed` property of a `SuppressedError`, when present.
+   */
+  suppressed?: SerializedError;
+  /**
    * Any other extra properties that have been attached to the object will also be present on the serialized object.
    */
   [key: string]: any;

--- a/lib/err.js
+++ b/lib/err.js
@@ -40,6 +40,15 @@ function errSerializer (err) {
       json.aggregateErrors = err.errors.map(e => errSerializer(e))
     }
 
+    // `error` and `suppressed` are non-enumerable own properties of
+    // SuppressedError, so serialize them explicitly when present.
+    if (isErrorLike(err.error) && !Object.prototype.hasOwnProperty.call(err.error, seen)) {
+      json.error = errSerializer(err.error)
+    }
+    if (isErrorLike(err.suppressed) && !Object.prototype.hasOwnProperty.call(err.suppressed, seen)) {
+      json.suppressed = errSerializer(err.suppressed)
+    }
+
     json.raw = err
     return json
   }
@@ -68,6 +77,16 @@ function errSerializer (err) {
         _err[key] = val
       }
     }
+  }
+
+  // `error` and `suppressed` are non-enumerable own properties of
+  // SuppressedError, so the for..in loop above skips them. Serialize them
+  // explicitly when present.
+  if (_err.error === undefined && isErrorLike(err.error) && !Object.prototype.hasOwnProperty.call(err.error, seen)) {
+    _err.error = errSerializer(err.error)
+  }
+  if (_err.suppressed === undefined && isErrorLike(err.suppressed) && !Object.prototype.hasOwnProperty.call(err.suppressed, seen)) {
+    _err.suppressed = errSerializer(err.suppressed)
   }
 
   delete err[seen] // clean up tag in case err is serialized again later

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -284,6 +284,25 @@ test('uses toJSON() with error causes', () => {
   assert.strictEqual(serialized.name, 'MyError')
 })
 
+test('serializes SuppressedError error and suppressed', { skip: !global.SuppressedError }, () => {
+  const error = new Error('the operation failed')
+  const suppressed = new Error('disposal also failed')
+  const err = new global.SuppressedError(error, suppressed, 'an error was suppressed during disposal')
+
+  const serialized = serializer(err)
+
+  assert.strictEqual(serialized.type, 'SuppressedError')
+  assert.strictEqual(serialized.message, 'an error was suppressed during disposal')
+
+  assert.strictEqual(serialized.error.type, 'Error')
+  assert.strictEqual(serialized.error.message, 'the operation failed')
+  assert.match(serialized.error.stack, /Error: the operation failed/)
+
+  assert.strictEqual(serialized.suppressed.type, 'Error')
+  assert.strictEqual(serialized.suppressed.message, 'disposal also failed')
+  assert.match(serialized.suppressed.stack, /Error: disposal also failed/)
+})
+
 test('uses toJSON() - custom fields not added if not in toJSON output', () => {
   class MyError extends Error {
     constructor (message) {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -64,6 +64,12 @@ const mySerializer = wrapErrorSerializer(customErrorSerializer);
 const fakeErrorWithCause = new Error('A fake error for testing with cause', { cause: new Error('An inner fake error') });
 const serializedErrorWithCause: SerializedError = errWithCause(fakeError);
 
+// SuppressedError exposes serialized `error` and `suppressed` properties
+const suppressedError = new SuppressedError(new Error('error'), new Error('suppressed'), 'message');
+const serializedSuppressedError: SerializedError = err(suppressedError);
+serializedSuppressedError.error satisfies SerializedError | undefined;
+serializedSuppressedError.suppressed satisfies SerializedError | undefined;
+
 // Error-like objects (not instances of Error) should be accepted
 const errorLikeObj: ErrorLike = { message: 'custom error', stack: 'at foo.js:1:1' }
 const serializedErrorLike: SerializedError = err(errorLikeObj)


### PR DESCRIPTION
## Summary

The error serializer drops the `error` and `suppressed` properties of a `SuppressedError` (they are non-enumerable own properties, so the `for...in` loop skips them). This serializes them explicitly via `errSerializer`, gated on the `seen` symbol.

Closes #199