### PR TITLE
fix: keep err.raw non-enumerable on toJSON() path

### DIFF
--- a/lib/err.js
+++ b/lib/err.js
@@ -40,7 +40,12 @@ function errSerializer (err) {
       json.aggregateErrors = err.errors.map(e => errSerializer(e))
     }
 
-    json.raw = err
+    Object.defineProperty(json, 'raw', {
+      value: err,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    })
     return json
   }
 

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -124,6 +124,14 @@ test('err.raw is available', () => {
   assert.strictEqual(serialized.raw, err)
 })
 
+test('err.raw is non-enumerable and omitted from JSON', () => {
+  const err = Error('foo')
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.raw, err)
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(serialized, 'raw'), false)
+  assert.ok(!Object.hasOwn(JSON.parse(JSON.stringify(serialized)), 'raw'))
+})
+
 test('redefined err.constructor doesnt crash serializer', () => {
   function check (a, name) {
     assert.strictEqual(a.type, name)
@@ -222,6 +230,8 @@ test('uses toJSON() from class prototype', () => {
   assert.ok(serialized.stack) // stack should still be added by serializer
   assert.strictEqual(serialized.type, 'MyError') // type should be added
   assert.strictEqual(serialized.raw, err) // raw should be present
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(serialized, 'raw'), false)
+  assert.ok(!Object.hasOwn(JSON.parse(JSON.stringify(serialized)), 'raw'))
 })
 
 test('uses toJSON() with custom type when toJSON returns partial data', () => {


### PR DESCRIPTION
## Summary

- On the `toJSON()` path, `raw` was assigned with a plain property write, so it was enumerable and appeared in JSON output.
- That diverged from the documented contract (`raw` is non-enumerable / not in the output) and from the normal `pinoErrProto` path.
- Attach `raw` with `Object.defineProperty(..., { enumerable: false })` and add regression tests for both the normal and `toJSON()` paths.

## Test plan

- [x] `npm test` (73 tests pass)
- [x] `npm run lint`
- [x] Smoke check: `serialized.raw` still available; `propertyIsEnumerable('raw') === false`; parsed JSON has no `raw` key for both paths
