### PR TITLE
fix: serialize frozen and other non-extensible errors

### DIFF
--- a/lib/err-proto.js
+++ b/lib/err-proto.js
@@ -3,6 +3,11 @@
 const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
 
+// Tracks the errors being serialized in the current pass. A WeakSet is used
+// instead of tagging the error itself so that frozen, sealed, and otherwise
+// non-extensible errors can be serialized.
+const seenErrors = new WeakSet()
+
 const pinoErrProto = Object.create({}, {
   type: {
     enumerable: true,
@@ -41,6 +46,7 @@ Object.defineProperty(pinoErrProto, rawSymbol, {
 
 module.exports = {
   pinoErrProto,
+  seenErrors,
   pinoErrorSymbols: {
     seen,
     rawSymbol

--- a/lib/err-proto.js
+++ b/lib/err-proto.js
@@ -1,12 +1,6 @@
 'use strict'
 
-const seen = Symbol('circular-ref-tag')
 const rawSymbol = Symbol('pino-raw-err-ref')
-
-// Tracks the errors being serialized in the current pass. A WeakSet is used
-// instead of tagging the error itself so that frozen, sealed, and otherwise
-// non-extensible errors can be serialized.
-const seenErrors = new WeakSet()
 
 const pinoErrProto = Object.create({}, {
   type: {
@@ -46,9 +40,7 @@ Object.defineProperty(pinoErrProto, rawSymbol, {
 
 module.exports = {
   pinoErrProto,
-  seenErrors,
   pinoErrorSymbols: {
-    seen,
     rawSymbol
   }
 }

--- a/lib/err-with-cause.js
+++ b/lib/err-with-cause.js
@@ -3,8 +3,7 @@
 module.exports = errWithCauseSerializer
 
 const { isErrorLike } = require('./err-helpers')
-const { pinoErrProto, pinoErrorSymbols } = require('./err-proto')
-const { seen } = pinoErrorSymbols
+const { pinoErrProto, seenErrors } = require('./err-proto')
 
 const { toString } = Object.prototype
 
@@ -13,7 +12,7 @@ function errWithCauseSerializer (err) {
     return err
   }
 
-  err[seen] = undefined // tag to prevent re-looking at this
+  seenErrors.add(err) // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
   _err.type = toString.call(err.constructor) === '[object Function]'
     ? err.constructor.name
@@ -25,7 +24,7 @@ function errWithCauseSerializer (err) {
     _err.aggregateErrors = err.errors.map(err => errWithCauseSerializer(err))
   }
 
-  if (isErrorLike(err.cause) && !Object.prototype.hasOwnProperty.call(err.cause, seen)) {
+  if (isErrorLike(err.cause) && !seenErrors.has(err.cause)) {
     _err.cause = errWithCauseSerializer(err.cause)
   }
 
@@ -33,7 +32,7 @@ function errWithCauseSerializer (err) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (isErrorLike(val)) {
-        if (!Object.prototype.hasOwnProperty.call(val, seen)) {
+        if (!seenErrors.has(val)) {
           _err[key] = errWithCauseSerializer(val)
         }
       } else {
@@ -42,7 +41,7 @@ function errWithCauseSerializer (err) {
     }
   }
 
-  delete err[seen] // clean up tag in case err is serialized again later
+  seenErrors.delete(err) // clean up tag in case err is serialized again later
   _err.raw = err
   return _err
 }

--- a/lib/err-with-cause.js
+++ b/lib/err-with-cause.js
@@ -3,16 +3,24 @@
 module.exports = errWithCauseSerializer
 
 const { isErrorLike } = require('./err-helpers')
-const { pinoErrProto, seenErrors } = require('./err-proto')
+const { pinoErrProto } = require('./err-proto')
 
 const { toString } = Object.prototype
 
 function errWithCauseSerializer (err) {
+  return serializeError(err, new Set())
+}
+
+// `seen` holds the errors currently being serialized, so that circular
+// references terminate. It is local to one serialization pass, and lives
+// outside the error itself so that frozen, sealed, and otherwise
+// non-extensible errors can be serialized.
+function serializeError (err, seen) {
   if (!isErrorLike(err)) {
     return err
   }
 
-  seenErrors.add(err) // tag to prevent re-looking at this
+  seen.add(err) // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
   _err.type = toString.call(err.constructor) === '[object Function]'
     ? err.constructor.name
@@ -21,19 +29,19 @@ function errWithCauseSerializer (err) {
   _err.stack = err.stack
 
   if (Array.isArray(err.errors)) {
-    _err.aggregateErrors = err.errors.map(err => errWithCauseSerializer(err))
+    _err.aggregateErrors = err.errors.map(err => serializeError(err, seen))
   }
 
-  if (isErrorLike(err.cause) && !seenErrors.has(err.cause)) {
-    _err.cause = errWithCauseSerializer(err.cause)
+  if (isErrorLike(err.cause) && !seen.has(err.cause)) {
+    _err.cause = serializeError(err.cause, seen)
   }
 
   for (const key in err) {
     if (_err[key] === undefined) {
       const val = err[key]
       if (isErrorLike(val)) {
-        if (!seenErrors.has(val)) {
-          _err[key] = errWithCauseSerializer(val)
+        if (!seen.has(val)) {
+          _err[key] = serializeError(val, seen)
         }
       } else {
         _err[key] = val
@@ -41,7 +49,7 @@ function errWithCauseSerializer (err) {
     }
   }
 
-  seenErrors.delete(err) // clean up tag in case err is serialized again later
+  seen.delete(err) // clean up tag in case err is serialized again later
   _err.raw = err
   return _err
 }

--- a/lib/err.js
+++ b/lib/err.js
@@ -3,8 +3,7 @@
 module.exports = errSerializer
 
 const { messageWithCauses, stackWithCauses, isErrorLike } = require('./err-helpers')
-const { pinoErrProto, pinoErrorSymbols } = require('./err-proto')
-const { seen } = pinoErrorSymbols
+const { pinoErrProto, seenErrors } = require('./err-proto')
 
 const { toString } = Object.prototype
 
@@ -49,7 +48,7 @@ function errSerializer (err) {
     return json
   }
 
-  err[seen] = undefined // tag to prevent re-looking at this
+  seenErrors.add(err) // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
   _err.type = toString.call(err.constructor) === '[object Function]'
     ? err.constructor.name
@@ -66,7 +65,7 @@ function errSerializer (err) {
       const val = err[key]
       if (isErrorLike(val)) {
         // We append cause messages and stacks to _err, therefore skipping causes here
-        if (key !== 'cause' && !Object.prototype.hasOwnProperty.call(val, seen)) {
+        if (key !== 'cause' && !seenErrors.has(val)) {
           _err[key] = errSerializer(val)
         }
       } else {
@@ -75,7 +74,7 @@ function errSerializer (err) {
     }
   }
 
-  delete err[seen] // clean up tag in case err is serialized again later
+  seenErrors.delete(err) // clean up tag in case err is serialized again later
   _err.raw = err
   return _err
 }

--- a/lib/err.js
+++ b/lib/err.js
@@ -3,11 +3,19 @@
 module.exports = errSerializer
 
 const { messageWithCauses, stackWithCauses, isErrorLike } = require('./err-helpers')
-const { pinoErrProto, seenErrors } = require('./err-proto')
+const { pinoErrProto } = require('./err-proto')
 
 const { toString } = Object.prototype
 
 function errSerializer (err) {
+  return serializeError(err, new Set())
+}
+
+// `seen` holds the errors currently being serialized, so that circular
+// references terminate. It is local to one serialization pass, and lives
+// outside the error itself so that frozen, sealed, and otherwise
+// non-extensible errors can be serialized.
+function serializeError (err, seen) {
   if (!isErrorLike(err)) {
     return err
   }
@@ -36,7 +44,7 @@ function errSerializer (err) {
 
     // If the error has an errors array (AggregateError pattern), serialize it
     if (Array.isArray(err.errors)) {
-      json.aggregateErrors = err.errors.map(e => errSerializer(e))
+      json.aggregateErrors = err.errors.map(e => serializeError(e, seen))
     }
 
     Object.defineProperty(json, 'raw', {
@@ -48,7 +56,7 @@ function errSerializer (err) {
     return json
   }
 
-  seenErrors.add(err) // tag to prevent re-looking at this
+  seen.add(err) // tag to prevent re-looking at this
   const _err = Object.create(pinoErrProto)
   _err.type = toString.call(err.constructor) === '[object Function]'
     ? err.constructor.name
@@ -57,7 +65,7 @@ function errSerializer (err) {
   _err.stack = stackWithCauses(err)
 
   if (Array.isArray(err.errors)) {
-    _err.aggregateErrors = err.errors.map(err => errSerializer(err))
+    _err.aggregateErrors = err.errors.map(err => serializeError(err, seen))
   }
 
   for (const key in err) {
@@ -65,8 +73,8 @@ function errSerializer (err) {
       const val = err[key]
       if (isErrorLike(val)) {
         // We append cause messages and stacks to _err, therefore skipping causes here
-        if (key !== 'cause' && !seenErrors.has(val)) {
-          _err[key] = errSerializer(val)
+        if (key !== 'cause' && !seen.has(val)) {
+          _err[key] = serializeError(val, seen)
         }
       } else {
         _err[key] = val
@@ -74,7 +82,7 @@ function errSerializer (err) {
     }
   }
 
-  seenErrors.delete(err) // clean up tag in case err is serialized again later
+  seen.delete(err) // clean up tag in case err is serialized again later
   _err.raw = err
   return _err
 }

--- a/test/err-with-cause.test.js
+++ b/test/err-with-cause.test.js
@@ -104,6 +104,44 @@ test('cleans up infinite recursion tracking', () => {
   assert.ok(!serialized.inner.inner)
 })
 
+test('serializes non-extensible errors', () => {
+  for (const err of [
+    Object.freeze(Error('foo')),
+    Object.seal(Error('foo')),
+    Object.preventExtensions(Error('foo'))
+  ]) {
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.match(serialized.stack, /err-with-cause\.test\.js:/)
+  }
+})
+
+test('serializes a non-extensible error cause', () => {
+  const err = Error('foo', { cause: Object.freeze(Error('bar')) })
+
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.message, 'foo')
+  assert.strictEqual(serialized.cause.message, 'bar')
+})
+
+test('prevents infinite recursion on non-extensible errors', () => {
+  const err = Error('foo')
+  err.inner = err
+  Object.freeze(err)
+
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.type, 'Error')
+  assert.strictEqual(serialized.message, 'foo')
+  assert.ok(!serialized.inner)
+})
+
+test('does not add properties to the serialized error', () => {
+  const err = Error('foo')
+  serializer(err)
+  assert.deepStrictEqual(Object.getOwnPropertySymbols(err), [])
+})
+
 test('err.raw is available', () => {
   const err = Error('foo')
   const serialized = serializer(err)

--- a/test/err.test.js
+++ b/test/err.test.js
@@ -118,6 +118,36 @@ test('cleans up infinite recursion tracking', () => {
   assert.ok(!serialized.inner.inner)
 })
 
+test('serializes non-extensible errors', () => {
+  for (const err of [
+    Object.freeze(Error('foo')),
+    Object.seal(Error('foo')),
+    Object.preventExtensions(Error('foo'))
+  ]) {
+    const serialized = serializer(err)
+    assert.strictEqual(serialized.type, 'Error')
+    assert.strictEqual(serialized.message, 'foo')
+    assert.match(serialized.stack, /err\.test\.js:/)
+  }
+})
+
+test('prevents infinite recursion on non-extensible errors', () => {
+  const err = Error('foo')
+  err.inner = err
+  Object.freeze(err)
+
+  const serialized = serializer(err)
+  assert.strictEqual(serialized.type, 'Error')
+  assert.strictEqual(serialized.message, 'foo')
+  assert.ok(!serialized.inner)
+})
+
+test('does not add properties to the serialized error', () => {
+  const err = Error('foo')
+  serializer(err)
+  assert.deepStrictEqual(Object.getOwnPropertySymbols(err), [])
+})
+
 test('err.raw is available', () => {
   const err = Error('foo')
   const serialized = serializer(err)


### PR DESCRIPTION
`err` and `errWithCause` guard against circular references by tagging the error currently being serialized with a symbol property, then deleting the tag again at the end:

```js
err[seen] = undefined // tag to prevent re-looking at this
// ...
delete err[seen]
```

Both modules are strict mode, so that assignment throws a `TypeError` when the error is not extensible. Logging a frozen error takes the application down instead of writing a log line:

```js
const pino = require('pino')
const logger = pino()

logger.error(Object.freeze(new Error('boom')), 'oops')
// TypeError: Cannot add property Symbol(circular-ref-tag), object is not extensible
```

`Object.seal()` and `Object.preventExtensions()` fail the same way. It is reached through a plain `logger.error(err)`, and a logger arguably should not be able to throw on the error it was handed.

### Fix

Track the errors in the current pass in a `WeakSet` shared by both serializers, rather than tagging the errors themselves. The set is added to, checked, and cleared at exactly the points the symbol was, so the recursion behaviour is unchanged — the existing "prevents infinite recursion" and "cleans up infinite recursion tracking" tests still cover it — and the caller's error is no longer mutated at all.

Keeping the tag off the error also means a non-extensible error keeps its circular-reference protection. Simply guarding the tagging with `Object.isExtensible()` would not: it would swap the `TypeError` for a stack overflow on `err.inner = err`.

`seen` is left exported from `pinoErrorSymbols` in case anything deep-imports it, but nothing in this repo or in pino reads it any more — happy to drop it if you would prefer.

### Tests

Added to both `test/err.test.js` and `test/err-with-cause.test.js`:

- frozen / sealed / non-extensible errors serialize normally
- a frozen error is still protected against infinite recursion (`err.inner = err`)
- a non-extensible `cause` serializes (`errWithCause`)
- the serializer adds no own symbols to the error it is handed

The five new behaviour tests fail on `master` and pass with this change. Locally `npm test` (80 tests), `npm run lint-ci` and `npm run test-types` are green, and coverage of the touched files is unchanged.
