### PR TITLE
types: type errWithCause cause as a serialized error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ Serializes an `Error` like object, including any `error.cause`. Returns an objec
   type: 'string', // The name of the object's constructor.
   message: 'string', // The supplied error message.
   stack: 'string', // The stack when the error was generated.
-  cause?: Error, // If the original error had an error.cause, it will be serialized here
+  cause?: SerializedError, // Recursively serialized error.cause when the cause is Error-like
   raw: Error  // Non-enumerable, i.e. will not be in the output, original
               // Error object. This is available for subsequent serializers
               // to use.

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,18 @@ export interface SerializedError {
 }
 
 /**
+ * Serialized error produced by {@link errWithCause}. Unlike {@link SerializedError},
+ * Error-like `cause` values are serialized recursively onto this object.
+ */
+export interface SerializedErrorWithCause extends Omit<SerializedError, 'cause'> {
+  /**
+   * Recursively serialized `error.cause` when the cause is Error-like.
+   * Non-error causes are copied through unchanged.
+   */
+  cause?: SerializedErrorWithCause;
+}
+
+/**
  * Serializes an Error or Error-like object. Does not serialize "err.cause" fields
  * (will append the err.cause.message to err.message and err.cause.stack to err.stack).
  * Accepts any object with a `message` string property.
@@ -58,7 +70,7 @@ export function err(err: Error | ErrorLike): SerializedError;
  * Serializes an Error or Error-like object, including full serialization for any
  * err.cause fields recursively. Accepts any object with a `message` string property.
  */
-export function errWithCause(err: Error | ErrorLike): SerializedError;
+export function errWithCause(err: Error | ErrorLike): SerializedErrorWithCause;
 
 export interface SerializedRequest {
   /**

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -10,6 +10,7 @@ import {
   whatwgRes,
   ErrorLike,
   SerializedError,
+  SerializedErrorWithCause,
   SerializedRequest,
   wrapErrorSerializer,
   wrapRequestSerializer,
@@ -62,18 +63,22 @@ const serializedError: SerializedError = err(fakeError);
 const mySerializer = wrapErrorSerializer(customErrorSerializer);
 
 const fakeErrorWithCause = new Error('A fake error for testing with cause', { cause: new Error('An inner fake error') });
-const serializedErrorWithCause: SerializedError = errWithCause(fakeError);
+const serializedErrorWithCause: SerializedErrorWithCause = errWithCause(fakeErrorWithCause);
+serializedErrorWithCause.cause?.type
+serializedErrorWithCause.cause?.message
+serializedErrorWithCause.cause?.stack
+serializedErrorWithCause.cause?.cause?.message
 
 // Error-like objects (not instances of Error) should be accepted
 const errorLikeObj: ErrorLike = { message: 'custom error', stack: 'at foo.js:1:1' }
 const serializedErrorLike: SerializedError = err(errorLikeObj)
-const serializedErrorLikeWithCause: SerializedError = errWithCause(errorLikeObj)
+const serializedErrorLikeWithCause: SerializedErrorWithCause = errWithCause(errorLikeObj)
 const wrappedWithErrorLike = mySerializer(errorLikeObj)
 
 // Minimal error-like object (only message required)
 const minimalErrorLike = { message: 'just a message' }
 err(minimalErrorLike) satisfies SerializedError
-errWithCause(minimalErrorLike) satisfies SerializedError
+errWithCause(minimalErrorLike) satisfies SerializedErrorWithCause
 
 const request: IncomingMessage = {} as IncomingMessage
 const serializedRequest: SerializedRequest = req(request);


### PR DESCRIPTION
## What

`errWithCause` recursively serializes `error.cause` onto the returned object. The shared `SerializedError` type still declared `cause` as `never`, which is only correct for `err()`.

This adds `SerializedErrorWithCause` and uses it as the return type of `errWithCause`, matching the runtime tests and the README example.

Fixes #203

## Test plan

- [x] `npm run test-types`
- [x] `npm test`
- [x] `npm run lint-ci`